### PR TITLE
In the preview mode, do not error on every keystroke in insert mode

### DIFF
--- a/lua/polychrome/preview.lua
+++ b/lua/polychrome/preview.lua
@@ -118,8 +118,8 @@ function M.StartPreview(throttle_ms)
     HL_NAMESPACE = vim.api.nvim_create_namespace('polychrome_preview')
     AUGROUP_ID = vim.api.nvim_create_augroup('polychrome', { clear = true })
     vim.api.nvim_create_autocmd({
+        'InsertLeave',
         'TextChanged',
-        'TextChangedI',
         'TextChangedP',
         'TextChangedT',
     }, {


### PR DESCRIPTION
Hi, firstly thanks for the plugin, it's really useful. I especially love the preview feature with automatic reload :heart_eyes:. I just found a small issue there: in the preview mode, the plugin was erroring on every keystroke I made while making edits to the highlight definitions.

I expected the plugin to wait until I'm finished with inserting text and only then reapply the changes, thus I replaced the `TextChangedI` event by `InsertLeave`.
