### PR TITLE
Add diagnostics for live preview mode

### DIFF
--- a/lua/polychrome/colorscheme.lua
+++ b/lua/polychrome/colorscheme.lua
@@ -5,6 +5,58 @@ local GUI_FLAGS = require('polychrome.group').GUI_FLAGS
 
 local M = {}
 
+local DIAGNOSTIC_NAMESPACE = vim.api.nvim_create_namespace('polychrome')
+
+local function ts_find_color_error_location(group_name, value)
+    local tree = vim.treesitter.get_parser(0)
+    if tree == nil then
+        return nil
+    end
+
+    local root = tree:parse()[1]:root()
+
+    local query = vim.treesitter.query.parse('lua', ([[
+        (function_call
+          name: (identifier) @groupname (#eq? @groupname "%s")
+          arguments: (arguments
+            (table_constructor
+              (field
+                name: (identifier)
+                value: (string
+                  content: (string_content) @colorvalue (#eq? @colorvalue "%s"))))))
+    ]]):format(group_name, value))
+
+    for _, captures, _ in query:iter_matches(root, 0) do
+        ---@type TSNode
+        local value_node = captures[2]
+        local row, col, end_row, end_col = value_node:range()
+        if row ~= nil then
+            return { row, col, end_row, end_col }
+        end
+    end
+end
+
+local show_diagnostics_for = vim.schedule_wrap(function(errors)
+    vim.api.nvim_buf_clear_namespace(0, DIAGNOSTIC_NAMESPACE, 0, -1)
+
+    local diagnostics = {}
+    for _, entry in ipairs(errors) do
+        local _, _, bad_value = entry.error:find('Invalid highlight color: \'(.*)\'')
+        local ts_location = ts_find_color_error_location(entry.group.name, bad_value)
+
+        table.insert(diagnostics, {
+            message = "Invalid color value: '" .. bad_value .. "'",
+            severity = vim.diagnostic.severity.ERROR,
+            lnum = ts_location and ts_location[1] or entry.group._definition_locations[1].currentline or 0,
+            col = ts_location and ts_location[2] or 0,
+            end_lnum = ts_location and ts_location[3] or nil,
+            end_col = ts_location and ts_location[4] or nil,
+        })
+    end
+
+    vim.diagnostic.set(DIAGNOSTIC_NAMESPACE, 0, diagnostics)
+end)
+
 ---@class ColorschemeConfig
 ---@field inject_gui_groups boolean|nil Should some default groups be automatically defined?
 
@@ -70,6 +122,7 @@ M.Colorscheme = { ---@diagnostic disable-line: missing-fields
 
         vim.g.colors_name = self.name
 
+        local errors = vim.iter({})
         for name, group in pairs(self.groups) do
             local ok, result = pcall(function()
                 local hl = group:to_hl()
@@ -78,7 +131,15 @@ M.Colorscheme = { ---@diagnostic disable-line: missing-fields
             end)
 
             if not ok then
-                vim.notify('[polychrome] Error defining "' .. name .. '": ' .. result, vim.log.levels.ERROR)
+                table.insert(errors, { error = result, group = group })
+            end
+        end
+
+        if POLYCHROME_EDITING then
+            show_diagnostics_for(errors)
+        else
+            for name, error in pairs(errors:totable()) do
+                vim.notify('[' .. self.name .. '] Error defining "' .. name .. '": ' .. error, vim.log.levels.ERROR)
             end
         end
     end,
@@ -181,7 +242,7 @@ M.Colorscheme = { ---@diagnostic disable-line: missing-fields
 
         local function all_groups_defined_exactly_once()
             local redefined = groups_where(function(_, group)
-                return group._definition_count > 1
+                return vim.tbl_count(group._definition_locations) > 1
             end)
 
             if vim.tbl_count(redefined) == 0 then
@@ -191,7 +252,8 @@ M.Colorscheme = { ---@diagnostic disable-line: missing-fields
 
             for name, group in pairs(redefined) do
                 vim.health.warn(
-                    "Highlight group '" .. name .. "' was defined " .. group._definition_count .. " times."
+                    "Highlight group '" ..
+                    name .. "' was defined " .. vim.tbl_count(group._definition_locations) .. " times."
                 )
             end
         end

--- a/lua/polychrome/colorscheme.lua
+++ b/lua/polychrome/colorscheme.lua
@@ -72,7 +72,7 @@ M.Colorscheme = { ---@diagnostic disable-line: missing-fields
 
         vim.g.colors_name = self.name
 
-        local errors = vim.iter({})
+        local errors = {}
         for name, group in pairs(self.groups) do
             local ok, result = pcall(function()
                 local hl = group:to_hl()

--- a/lua/polychrome/diagnostics.lua
+++ b/lua/polychrome/diagnostics.lua
@@ -131,7 +131,7 @@ M.DIAGNOSTICS = DiagnosticManager:new()
 ---@param node TSNode
 ---@return TSNodeRange
 local function to_range(node)
-    local values = table.pack(node:range())
+    local values = { node:range() }
     return {
         row = values[1],
         col = values[2],

--- a/lua/polychrome/diagnostics.lua
+++ b/lua/polychrome/diagnostics.lua
@@ -1,0 +1,281 @@
+local Set = require('polychrome.utils').Set
+
+local M = {}
+
+---@alias PositionKey string
+
+---@class TSNodeRange
+---@field row number
+---@field col number
+---@field end_row number|nil
+---@field end_col number|nil
+---@field byte number|nil
+---@field end_byte number|nil
+
+---@class ErrorBag
+---@field type ErrorType
+---@field message string
+---@field group Group
+
+--- A manager for diagnostics, that dedupes and applies diagnostics to the buffer
+---
+---@class DiagnosticManager
+---@field _diagnostic_to_position_key fun(diagnostic: vim.Diagnostic): PositionKey
+---@field _position_key_to_diagnostic fun(key: PositionKey, message: string, severity: vim.diagnostic.Severity|nil): vim.Diagnostic
+---@field add fun(self: DiagnosticManager, diagnostics: vim.Diagnostic[])
+---@field remove fun(self: DiagnosticManager, diagnostics: vim.Diagnostic[])
+---@field clear fun(self: DiagnosticManager)
+---@field apply fun(self: DiagnosticManager)
+---@field get fun(self: DiagnosticManager): vim.Diagnostic[]
+local DiagnosticManager = {
+    new = function(self)
+        local obj = {}
+
+        setmetatable(obj, self)
+
+        return obj
+    end,
+
+    _diagnostic_to_position_key = function(diagnostic)
+        return ('%d:%d:%d:%d'):format(diagnostic.lnum, diagnostic.col, diagnostic.end_lnum, diagnostic.end_col)
+    end,
+
+    _position_key_to_diagnostic = function(key, message, severity)
+        local function parse(value)
+            if value == '' then
+                return nil
+            end
+            return tonumber(value)
+        end
+
+        local lnum, col, end_lnum, end_col = key:match('(%d+):(%d+):(%d+):(%d+)')
+        return {
+            lnum = parse(lnum),
+            col = parse(col),
+            end_lnum = parse(end_lnum),
+            end_col = parse(end_col),
+            message = message,
+            severity = severity or vim.diagnostic.severity.ERROR,
+        }
+    end,
+
+    add = function(self, diagnostics)
+        for _, diagnostic in ipairs(diagnostics) do
+            local key = self._diagnostic_to_position_key(diagnostic)
+            if not self[key] then
+                self[key] = Set:new()
+            end
+
+            self[key]:add(diagnostic.message)
+        end
+    end,
+
+    remove = function(self, diagnostics)
+        for _, diagnostic in ipairs(diagnostics) do
+            local key = self._diagnostic_to_position_key(diagnostic)
+
+            if self[key] == nil then
+                return
+            end
+
+            self[key]:remove(diagnostic.message)
+        end
+
+        self:apply()
+    end,
+
+    clear = function(self)
+        for key in pairs(self) do
+            self[key] = nil
+        end
+        self:apply()
+    end,
+
+    apply = vim.schedule_wrap(function(self, colorscheme)
+        local diagnostics = self:get()
+
+        if POLYCHROME_EDITING then
+            vim.api.nvim_buf_clear_namespace(0, M.DIAGNOSTIC_NAMESPACE, 0, -1)
+            vim.diagnostic.set(M.DIAGNOSTIC_NAMESPACE, 0, diagnostics)
+        else
+            for _, diagnostic in ipairs(diagnostics) do
+                vim.notify('[' .. (colorscheme and colorscheme.name or 'polychrome') .. '] ' .. diagnostic.message,
+                    vim.log.levels.ERROR)
+            end
+        end
+    end),
+
+    get = function(self)
+        local diagnostics = {}
+
+        for location, messages in pairs(self) do
+            for _, message in ipairs(messages:tolist()) do
+                local created = self._position_key_to_diagnostic(location, message)
+
+                table.insert(diagnostics, created)
+            end
+        end
+
+        return diagnostics
+    end,
+
+    __len = function(self)
+        return #self:get()
+    end,
+}
+DiagnosticManager.__index = DiagnosticManager
+
+M.DIAGNOSTIC_NAMESPACE = vim.api.nvim_create_namespace('polychrome')
+M.DIAGNOSTICS = DiagnosticManager:new()
+
+---@param node TSNode
+---@return TSNodeRange
+local function to_range(node)
+    local values = table.pack(node:range())
+    return {
+        row = values[1],
+        col = values[2],
+        end_row = values[3],
+        end_col = values[4],
+        byte = values[5],
+        end_byte = values[6],
+    }
+end
+
+local function ts_find_table_value(value)
+    local success, tree = pcall(vim.treesitter.get_parser, 0)
+    if not success then
+        return {}
+    end
+
+    local root = tree:parse()[1]:root()
+
+    local query = vim.treesitter.query.parse('lua', ([[
+        (field
+          name: (identifier)
+          value: (string
+            content: (string_content) @value (#eq? @value "%s")))
+    ]]):format(value))
+
+    local found = {}
+    for _, captures, _ in query:iter_matches(root, 0) do
+        ---@type TSNode
+        local value_node = captures[1]
+        if value_node ~= nil then
+            table.insert(found, to_range(value_node))
+        end
+    end
+
+    return found
+end
+
+local function ts_find_table_key(group_name, value)
+    local success, tree = pcall(vim.treesitter.get_parser, 0)
+    if not success then
+        return {}
+    end
+
+    local root = tree:parse()[1]:root()
+
+    local query = vim.treesitter.query.parse('lua', ([[
+        (function_call
+          name: (identifier) @group (#eq? @group "%s")
+          arguments: (arguments
+            (table_constructor
+              (field
+                name: (identifier) @key (#eq? @key "%s")))))
+    ]]):format(group_name, value))
+
+    local found = {}
+    for _, captures, _ in query:iter_matches(root, 0) do
+        ---@type TSNode
+        local value_node = captures[2]
+        if value_node ~= nil then
+            table.insert(found, to_range(value_node))
+        end
+    end
+
+    return found
+end
+
+---@enum ErrorType
+M.ERROR_TYPES = {
+    INVALID_COLOR = 1,
+    INVALID_ATTRIBUTE = 2,
+}
+
+---@type table<ErrorType, fun(error: ErrorBag): string>
+M.ERROR_MESSAGES = {
+    [M.ERROR_TYPES.INVALID_COLOR] = function(error)
+        return ('Invalid color: \'%s\''):format(error.message:match('Invalid highlight color: \'(.*)\''))
+    end,
+    [M.ERROR_TYPES.INVALID_ATTRIBUTE] = function(error)
+        return ('Invalid attribute name: %s'):format(error.message:match('Invalid attribute: \'(.*)\''))
+    end,
+}
+
+---@type table<ErrorType, fun(error: ErrorBag): TSNodeRange[]>
+M.REFINE_ERROR_LOCATION = {
+    [M.ERROR_TYPES.INVALID_COLOR] = function(error)
+        local _, _, bad_value = error.message:find('Invalid highlight color: \'(.*)\'')
+
+        return ts_find_table_value(bad_value)
+    end,
+    [M.ERROR_TYPES.INVALID_ATTRIBUTE] = function(error)
+        local _, _, bad_value = error.message:find('Invalid attribute: \'(.*)\'')
+
+        return ts_find_table_key(error.group.name, bad_value)
+    end,
+}
+
+---@type fun(error: ErrorBag): vim.Diagnostic[]
+local function create_diagnostics_from_error(error)
+    ---@type vim.Diagnostic[]
+    local diagnostics = {}
+    local ranges = M.REFINE_ERROR_LOCATION[error.type](error)
+
+    -- use the original error location if we couldn't find a better one
+    if #ranges == 0 then
+        table.insert(ranges, {
+            row = error.group._definition_locations[1].currentline or 0,
+            col = 0,
+        })
+    end
+
+    for _, location in ipairs(ranges) do
+        table.insert(diagnostics, {
+            message = M.ERROR_MESSAGES[error.type](error),
+            severity = vim.diagnostic.severity.ERROR,
+            lnum = location.row,
+            col = location.col,
+            end_lnum = location.end_row or location.row,
+            end_col = location.end_col or location.col,
+        })
+    end
+
+    return diagnostics
+end
+
+---@type fun(errors: ErrorBag[])
+local function register_errors(errors)
+    local diagnostics = {}
+    for _, error in ipairs(errors) do
+        local new = create_diagnostics_from_error(error)
+        vim.list_extend(diagnostics, new)
+    end
+
+    M.DIAGNOSTICS:add(diagnostics)
+end
+
+---@type fun(errors: ErrorBag[])
+M.add = vim.schedule_wrap(register_errors)
+
+M.clear = function()
+    M.DIAGNOSTICS:clear()
+end
+
+M.show = function(colorscheme)
+    M.DIAGNOSTICS:apply(colorscheme)
+end
+
+return M

--- a/lua/polychrome/group.lua
+++ b/lua/polychrome/group.lua
@@ -1,3 +1,4 @@
+local diagnostics = require "polychrome.diagnostics"
 local M = {}
 
 --- The options that hold the actual color values.
@@ -118,8 +119,11 @@ M.Group = { ---@diagnostic disable-line: missing-fields
 
     set = function(self, key, value)
         if not (vim.tbl_contains(M.ALLOWED_KEYS, key) or type(key) == "number") then
-            vim.notify("[polychrome] Invalid attribute '" .. key .. "' for highlight group '" .. self.name .. "'.",
-                vim.log.levels.WARN)
+            diagnostics.add({ {
+                type = diagnostics.ERROR_TYPES.INVALID_ATTRIBUTE,
+                message = "Invalid attribute: '" .. key .. "'",
+                group = self,
+            } })
             goto finish
         end
 

--- a/lua/polychrome/group.lua
+++ b/lua/polychrome/group.lua
@@ -65,7 +65,7 @@ end
 ---@field name string
 ---@field attributes GroupAttributes
 ---@field links Group[]
----@field _definition_count number
+---@field _definition_locations debuginfo[]
 ---@field __call fun(self: Group, attrs: table)
 ---@field set fun(self: Group, key: string, value: any): Group Set the given attribute to the given value
 ---@field is_combo_link fun(self: Group): boolean Is a link present along with other attributes?
@@ -92,7 +92,7 @@ M.Group = { ---@diagnostic disable-line: missing-fields
         new.name = name
         new.attributes = {}
         new.links = {}
-        new._definition_count = 0
+        new._definition_locations = {}
 
         setmetatable(new, M.Group)
 
@@ -108,7 +108,7 @@ M.Group = { ---@diagnostic disable-line: missing-fields
 
     __call = function(self, attrs)
         -- used in health checks to see if a group was defined multiple times
-        self._definition_count = self._definition_count + 1
+        table.insert(self._definition_locations, debug.getinfo(4))
 
         -- vim.iter.each walks both list and dict-like keys in tables
         vim.iter(pairs(attrs)):each(function(key, value)

--- a/lua/polychrome/preview.lua
+++ b/lua/polychrome/preview.lua
@@ -74,18 +74,14 @@ local function apply_colorscheme()
     -- load current file
     ---@type Colorscheme|true|nil
     POLYCHROME_EDITING = true
-    local definition, err = load(utils.read_buffer(0))
+    local definition = load(utils.read_buffer(0))
     if not definition then
-        if err then
-            vim.notify(err)
-        end
         return -- not runnable
     end
 
     -- run it
-    local ok, result = pcall(definition)
+    local ok = pcall(definition)
     if not ok then
-        vim.notify(result)
         return
     end
 
@@ -116,8 +112,7 @@ local function clear_preview()
 end
 
 --- Activate a live preview of the colorscheme.
----@param throttle_ms number|nil
-function M.StartPreview(throttle_ms)
+function M.StartPreview()
     PREVIOUS_COLORSCHEME = vim.g.colors_name
 
     -- start with a clean slate

--- a/lua/polychrome/preview.lua
+++ b/lua/polychrome/preview.lua
@@ -118,8 +118,8 @@ function M.StartPreview(throttle_ms)
     HL_NAMESPACE = vim.api.nvim_create_namespace('polychrome_preview')
     AUGROUP_ID = vim.api.nvim_create_augroup('polychrome', { clear = true })
     vim.api.nvim_create_autocmd({
-        'InsertLeave',
         'TextChanged',
+        'TextChangedI',
         'TextChangedP',
         'TextChangedT',
     }, {

--- a/lua/polychrome/preview.lua
+++ b/lua/polychrome/preview.lua
@@ -113,10 +113,10 @@ end
 
 --- Activate a live preview of the colorscheme.
 function M.StartPreview()
-    PREVIOUS_COLORSCHEME = vim.g.colors_name
-
     -- start with a clean slate
-    clear_preview()
+    M.StopPreview()
+
+    PREVIOUS_COLORSCHEME = vim.g.colors_name
 
     -- register the live preview
     AUGROUP_ID = vim.api.nvim_create_augroup('polychrome_preview', { clear = true })

--- a/lua/polychrome/preview.lua
+++ b/lua/polychrome/preview.lua
@@ -1,12 +1,13 @@
 local utils = require('polychrome.utils')
+local diagnostics = require('polychrome.diagnostics')
 
 local M = {}
 
-local HL_NAMESPACE = nil
+local PREVIEW_NAMESPACE = vim.api.nvim_create_namespace('polychrome_preview')
 --- The ID of the augroup for our autocommands
 local AUGROUP_ID = nil
---- Number of the buffer the live preview was activated on
-local BUFNR = nil
+---@type string|nil
+local PREVIOUS_COLORSCHEME = nil
 
 -- whitespace or quote mark directly before start of name
 local _HL_NAME_LEADING_PATTERN = [=[[%s"']]=]
@@ -19,13 +20,13 @@ local HL_NAME_REGEX = _HL_NAME_LEADING_PATTERN .. _HL_NAME_CAPTURE .. _HL_NAME_T
 local COLOR_REGEX = [[(%w+)%(([%d%.]+)%s*,%s*([%d%.]+)%s*,%s*([%d%.]+)%s*%)]]
 
 local function clear_highlights()
-    pcall(vim.api.nvim_buf_clear_namespace, BUFNR, HL_NAMESPACE, 0, -1)
+    pcall(vim.api.nvim_buf_clear_namespace, 0, PREVIEW_NAMESPACE, 0, -1)
 end
 
 local function apply_hl_group_name_hl(groups, line_nr, line)
     local start, _end, match = line:find(HL_NAME_REGEX)
     if match and groups[match] ~= nil then
-        vim.api.nvim_buf_add_highlight(BUFNR, HL_NAMESPACE, match, line_nr - 1, start or 0, _end - 1 or -1)
+        vim.api.nvim_buf_add_highlight(0, PREVIEW_NAMESPACE, match, line_nr - 1, start or 0, _end - 1 or -1)
     end
 end
 
@@ -35,13 +36,17 @@ local function apply_color_obj_hl(groups, line_nr, line)
     if start ~= nil then
         name = string.lower(name)
 
-        local class = require('polychrome')[name]
+        local class = require('polychrome.color')[name]
         if class.is_color_object then
             local color = class(tonumber(a), tonumber(b), tonumber(c))
+            if not color then
+                return
+            end
+
             local hl_name = table.concat({ name, a, b, c }, '')
 
             vim.api.nvim_set_hl(0, hl_name, { fg = 'black', bg = color:hex() })
-            vim.api.nvim_buf_add_highlight(BUFNR, HL_NAMESPACE, hl_name, line_nr - 1, start - 1, _end or -1)
+            vim.api.nvim_buf_add_highlight(0, PREVIEW_NAMESPACE, hl_name, line_nr - 1, start - 1, _end or -1)
         end
     end
 end
@@ -49,7 +54,7 @@ end
 --- Highlight all currently-defined highlight groups
 local function apply_highlights()
     local groups = utils.get_highlight_groups()
-    local lines = vim.api.nvim_buf_get_lines(BUFNR or 0, 0, -1, false)
+    local lines = vim.api.nvim_buf_get_lines(0 or 0, 0, -1, false)
 
     for idx, line in ipairs(lines) do
         apply_hl_group_name_hl(groups, idx, line)
@@ -60,7 +65,7 @@ end
 --- Extract a colorscheme from the current buffer.
 local function apply_colorscheme()
     if vim.bo.filetype ~= 'lua' then
-        print('[polychrome] Cannot live reload colorscheme because it is not a Lua file!')
+        vim.notify('[polychrome] Cannot live reload colorscheme because it is not a Lua file!')
     end
 
     -- clear any previous matches
@@ -69,22 +74,24 @@ local function apply_colorscheme()
     -- load current file
     ---@type Colorscheme|true|nil
     POLYCHROME_EDITING = true
-    local definition, result = load(utils.read_buffer(BUFNR))
+    local definition, err = load(utils.read_buffer(0))
     if not definition then
-        print(result)
+        if err then
+            vim.notify(err)
+        end
         return -- not runnable
     end
 
     -- run it
     local ok, result = pcall(definition)
     if not ok then
-        print(result)
+        vim.notify(result)
         return
     end
 
     -- check if a definition was run in the file
     if POLYCHROME_EDITING == nil or POLYCHROME_EDITING == true then
-        print('[polychrome] Could not find a colorscheme through the current buffer!')
+        vim.notify('[polychrome] Could not find a colorscheme through the current buffer!')
         return
     end
 
@@ -104,26 +111,27 @@ end
 
 local function clear_preview()
     clear_highlights()
+    diagnostics.clear()
     pcall(vim.api.nvim_del_augroup_by_id, AUGROUP_ID)
 end
 
 --- Activate a live preview of the colorscheme.
 ---@param throttle_ms number|nil
 function M.StartPreview(throttle_ms)
+    PREVIOUS_COLORSCHEME = vim.g.colors_name
+
     -- start with a clean slate
     clear_preview()
 
     -- register the live preview
-    BUFNR = vim.fn.bufnr()
-    HL_NAMESPACE = vim.api.nvim_create_namespace('polychrome_preview')
-    AUGROUP_ID = vim.api.nvim_create_augroup('polychrome', { clear = true })
+    AUGROUP_ID = vim.api.nvim_create_augroup('polychrome_preview', { clear = true })
     vim.api.nvim_create_autocmd({
         'TextChanged',
         'TextChangedI',
         'TextChangedP',
         'TextChangedT',
     }, {
-        buffer = BUFNR,
+        buffer = 0,
         group = AUGROUP_ID,
         callback = apply_preview,
     })
@@ -135,6 +143,11 @@ end
 --- Deactivate the live preview of the colorscheme.
 function M.StopPreview()
     clear_preview()
+
+    if PREVIOUS_COLORSCHEME ~= nil then
+        vim.cmd.colorscheme(PREVIOUS_COLORSCHEME)
+        PREVIOUS_COLORSCHEME = nil
+    end
 end
 
 return M

--- a/lua/polychrome/utils.lua
+++ b/lua/polychrome/utils.lua
@@ -156,4 +156,46 @@ function M.sign(x)
     end
 end
 
+---@class M.Set
+---@field new fun(self: M.Set, ...: string[]): M.Set
+---@field add fun(self: M.Set, ...: string[])
+---@field remove fun(self: M.Set, ...: string[])
+---@field has fun(self: M.Set, value: string): boolean
+---@field tolist fun(self: M.Set): string[]
+M.Set = {
+    new = function(self, ...)
+        local args = { ... }
+        local obj = {}
+
+        setmetatable(obj, self)
+
+        obj:add(unpack(args))
+
+        return obj
+    end,
+
+    add = function(self, ...)
+        local args = { ... }
+        for _, value in ipairs(args) do
+            self[value] = true
+        end
+    end,
+
+    remove = function(self, ...)
+        local args = { ... }
+        for _, value in ipairs(args) do
+            self[value] = nil
+        end
+    end,
+
+    has = function(self, value)
+        return self[value] ~= nil
+    end,
+
+    tolist = function(self)
+        return vim.tbl_keys(self)
+    end,
+}
+M.Set.__index = M.Set
+
 return M

--- a/lua/polychrome/utils.lua
+++ b/lua/polychrome/utils.lua
@@ -156,46 +156,4 @@ function M.sign(x)
     end
 end
 
----@class M.Set
----@field new fun(self: M.Set, ...: string[]): M.Set
----@field add fun(self: M.Set, ...: string[])
----@field remove fun(self: M.Set, ...: string[])
----@field has fun(self: M.Set, value: string): boolean
----@field tolist fun(self: M.Set): string[]
-M.Set = {
-    new = function(self, ...)
-        local args = { ... }
-        local obj = {}
-
-        setmetatable(obj, self)
-
-        obj:add(unpack(args))
-
-        return obj
-    end,
-
-    add = function(self, ...)
-        local args = { ... }
-        for _, value in ipairs(args) do
-            self[value] = true
-        end
-    end,
-
-    remove = function(self, ...)
-        local args = { ... }
-        for _, value in ipairs(args) do
-            self[value] = nil
-        end
-    end,
-
-    has = function(self, value)
-        return self[value] ~= nil
-    end,
-
-    tolist = function(self)
-        return vim.tbl_keys(self)
-    end,
-}
-M.Set.__index = M.Set
-
 return M


### PR DESCRIPTION
Adds diagnostics for the live preview mode (`:StartPreview`).

When in live preview mode, any definition errors are shown as diagnostics on the file being previewed (so they appear however the user has their diagnostics configured). When loading a colorscheme with errors normally, the errors are sent via `vim.notify` so that they are still surfaced to users. Currently, 2 types of errors are shown: invalid color values (ex: `#21212` instead of `#212121`), or unknown attribute names (ex: `Comment { f = "red" }` instead of `Comment { fg = "red" }`).

![image](https://github.com/user-attachments/assets/a4be3e0a-f309-40ce-a483-f111da4aa79c)

(This example shows the diagnostics as they appear via lsp_lines.nvim)

I also realized that we weren't wasn't properly resetting the highlights on `:StopPreview`, so I made it so that the active colorscheme is saved when calling `:StartPreview`, and then we call `:colorscheme <previous colorscheme>` on `:StopPreview`.
