### PR TITLE
Nest commands under new `:Polychrome` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,26 @@ you format your project properly.
 
 ## Quick Start
 
-If you just want to start testing things out, create a file named
-`your_theme.lua`, and populate it with the following:
+To start testing things out, open a new (empty) buffer and run `:Polychrome
+template theme`. This will fill the buffer with an empty colorscheme that
+contains all the most common highlight groups, and looks something like this:
 
 ```lua
 local Colorscheme = require('polychrome').Colorscheme
 
 -- replace `your_theme` with the name of your colorscheme
 Colorscheme.define('your_theme', function ()
-    -- Normal { fg = rgb(150, 150, 219), bg = rgb(20, 20, 20) }
+    -- Normal { }
+    -- Comment { }
+
+    -- ...many other highlight groups
 end)
 ```
 
-Then, while editing that file, do `:StartPreview`.
-
-You can then start adding highlights, and you'll instantly see the changes in
-your current window.
+Then, run `:Polychrome preview` (or `:Polychrome preview start`) to enable the
+live preview mode. You can then start setting highlights, and you'll instantly
+see the changes in your current window. You can disable the live preview mode
+with `:Polychrome preview stop`.
 
 > [!IMPORTANT]
 > If you are planning on creating a full colorscheme plugin, you may want to
@@ -326,9 +330,9 @@ end, { inject_gui_groups = false })
 
 ### Live Preview
 
-You can turn on a dynamic preview of your colorscheme via the `:StartPreview`
-command, or `require('polychrome').StartPreview()` from a Lua context. Running
-this command does the following:
+You can turn on a dynamic preview of your colorscheme via the `:Polychrome
+preview start` command, or `require('polychrome.preview').start()` from a Lua
+context. Running this command does the following:
 
   1. Runs the contents of the current buffer, and reapplies any colorscheme
      defined anywhere within it (even via `require`).
@@ -337,12 +341,13 @@ this command does the following:
      occurences of `Comment` in the buffer will be highlighted with the
      "Comment" highlight group)
 
-`StartPreview()` registers these actions via autocmd (specifically
-`TextChanged`, `TextChangedI`, `TextChangedP`, and `TextChangedT`), and
-throttles reloads to every 500ms by default, shared across the autocommands.
+`require('polychrome.preview').start()` registers these actions via autocmd
+(specifically `TextChanged`, `TextChangedI`, `TextChangedP`, and
+`TextChangedT`), and throttles reloads to every 500ms by default, shared across
+the autocommands.
 
-You can deactivate the live editing mode with `:StopPreview`, or
-`require('polychrome').StopPreview()` from a Lua context.
+You can deactivate the live editing mode with `:Polychrome preview stop`, or
+`require('polychrome.preview').stop()` from a Lua context.
 
 ## Finding highlight groups
 

--- a/lua/polychrome/commands.lua
+++ b/lua/polychrome/commands.lua
@@ -1,0 +1,113 @@
+local preview = require('polychrome.preview')
+local templates = require('polychrome.templates')
+
+local M = {}
+
+---@class Command
+---@field _default string
+---@field new fun(subcommands: table<string, any>, default: string|nil): Command
+---@field make_handler fun(self: Command): fun(args: table)
+---@field make_complete_handler fun(self: Command): fun(arg_lead: string, cmd_line: string, cursor_pos: number): table
+local Command = {}
+
+---@generic K
+---@param subcommands table<K|'_default', any>
+---@param default K|nil
+Command.new = function(subcommands, default)
+    local o = subcommands
+    o._default = default
+
+    setmetatable(o, Command)
+    return o
+end
+
+Command.__call = function(self, sub, ...)
+    if sub == nil and self._default == nil then
+        print('You must specify a subcommand! (valid subcommands: ' .. table.concat(vim.tbl_keys(self), ', ') .. ')')
+        return
+    end
+
+    local func = self[sub]
+
+    if func == nil then
+        print('Unknown subcommand: ' .. sub)
+        return
+    end
+
+    return func(...)
+end
+
+Command.make_handler = function(self)
+    ---@param args table
+    return function(args)
+        self((unpack or table.unpack)(args.fargs))
+    end
+end
+
+Command.make_complete_handler = function(self)
+    return function(arg_lead, cmd_line, cursor_pos)
+        local before_arg_lead = string.gsub(cmd_line, arg_lead, '')
+        local args = vim.split(before_arg_lead, ' ', { trimempty = true })
+        -- drop the first (root) arg
+        args = vim.list_slice(args, 2)
+
+        ---@type table
+        local cmd = self
+        -- step through each level of subcommands
+        for _, v in ipairs(args) do
+            -- get the next subcommand
+            local sub = cmd[v]
+
+            -- we are at the bottom, no more subcommands
+            if getmetatable(sub) ~= Command then
+                -- nothing left to suggest
+                cmd = {}
+                break
+            end
+
+            cmd = sub
+        end
+
+        local subcommands = vim.tbl_filter(function(v) return v ~= '_default' end, vim.tbl_keys(cmd))
+        table.sort(subcommands)
+
+        return subcommands
+    end
+end
+
+Command.__index = function(self, key)
+    if key == nil then
+        return self[self._default]
+    end
+
+    return Command[key]
+end
+
+local COMMANDS = Command.new({
+    preview = Command.new({
+        start = preview.start,
+        stop = preview.stop,
+    }, 'start'),
+    template = Command.new({
+        theme = templates.load_theme_template,
+    }),
+})
+
+M.setup = function()
+    vim.api.nvim_create_user_command('Polychrome', COMMANDS:make_handler(),
+        { nargs = '+', complete = COMMANDS:make_complete_handler() })
+
+    -- deprecated commands
+    vim.api.nvim_create_user_command('StartPreview', function()
+        vim.deprecate(":StartPreview", ":Polychrome preview or :Polychrome preview start", "future versions",
+            "polychrome.nvim",
+            false)
+        preview.start()
+    end, {})
+    vim.api.nvim_create_user_command('StopPreview', function()
+        vim.deprecate(":StopPreview", ":Polychrome preview stop", "future versions", "polychrome.nvim", false)
+        preview.stop()
+    end, {})
+end
+
+return M

--- a/lua/polychrome/commands.lua
+++ b/lua/polychrome/commands.lua
@@ -93,7 +93,13 @@ local COMMANDS = Command.new({
     }),
 })
 
+local commands_loaded = false
+
 M.setup = function()
+    if commands_loaded then
+        return
+    end
+
     vim.api.nvim_create_user_command('Polychrome', COMMANDS:make_handler(),
         { nargs = '+', complete = COMMANDS:make_complete_handler() })
 
@@ -108,6 +114,8 @@ M.setup = function()
         vim.deprecate(":StopPreview", ":Polychrome preview stop", "future versions", "polychrome.nvim", false)
         preview.stop()
     end, {})
+
+    commands_loaded = true
 end
 
 return M

--- a/lua/polychrome/commands.lua
+++ b/lua/polychrome/commands.lua
@@ -89,7 +89,7 @@ local COMMANDS = Command.new({
         stop = preview.stop,
     }, 'start'),
     template = Command.new({
-        theme = templates.load_theme_template,
+        theme = templates.read_into_current_buffer_factory('theme.lua.template'),
     }),
 })
 

--- a/lua/polychrome/init.lua
+++ b/lua/polychrome/init.lua
@@ -1,6 +1,6 @@
 local colorscheme = require('polychrome.colorscheme')
 local color = require('polychrome.color')
-local preview = require('polychrome.preview')
+local commands = require('polychrome.commands')
 
 local M = {
     Colorscheme = colorscheme.Colorscheme,
@@ -11,11 +11,8 @@ local M = {
     oklch = color.oklch,
     ciexyz = color.ciexyz,
     lms = color.lms,
-    StartPreview = preview.StartPreview,
-    StopPreview = preview.StopPreview,
 }
 
-vim.api.nvim_create_user_command('StartPreview', function() preview.StartPreview() end, {})
-vim.api.nvim_create_user_command('StopPreview', function() preview.StopPreview() end, {})
+commands.setup()
 
 return M

--- a/lua/polychrome/preview.lua
+++ b/lua/polychrome/preview.lua
@@ -112,9 +112,9 @@ local function clear_preview()
 end
 
 --- Activate a live preview of the colorscheme.
-function M.StartPreview()
+function M.start()
     -- start with a clean slate
-    M.StopPreview()
+    M.stop()
 
     PREVIOUS_COLORSCHEME = vim.g.colors_name
 
@@ -136,7 +136,7 @@ function M.StartPreview()
 end
 
 --- Deactivate the live preview of the colorscheme.
-function M.StopPreview()
+function M.stop()
     clear_preview()
 
     if PREVIOUS_COLORSCHEME ~= nil then

--- a/lua/polychrome/templates.lua
+++ b/lua/polychrome/templates.lua
@@ -1,0 +1,14 @@
+local utils = require('polychrome.utils')
+
+local M = {}
+
+M.load_theme_template = function()
+    local root = utils.get_plugin_root()
+    local template = vim.fs.joinpath(root, 'templates', 'theme.lua.template')
+
+    vim.cmd('silent keepalt read ' .. template)
+    vim.cmd.normal('ggdd')
+    vim.o.filetype = 'lua'
+end
+
+return M

--- a/lua/polychrome/templates.lua
+++ b/lua/polychrome/templates.lua
@@ -2,13 +2,25 @@ local utils = require('polychrome.utils')
 
 local M = {}
 
-M.load_theme_template = function()
+--- Read the given template into the current buffer.
+---
+---@param filename string
+M.read_into_current_buffer = function(filename)
     local root = utils.get_plugin_root()
-    local template = vim.fs.joinpath(root, 'templates', 'theme.lua.template')
+    local template = vim.fs.joinpath(root, 'templates', filename)
 
     vim.cmd('silent keepalt read ' .. template)
     vim.cmd.normal('ggdd')
     vim.o.filetype = 'lua'
+end
+
+--- Create a function that reads the given template into the current buffer.
+---
+---@param filename string
+M.read_into_current_buffer_factory = function(filename)
+    return function()
+        M.read_into_current_buffer(filename)
+    end
 end
 
 return M

--- a/lua/polychrome/templates/theme.lua.template
+++ b/lua/polychrome/templates/theme.lua.template
@@ -1,0 +1,302 @@
+local Colorscheme = require("polychrome").Colorscheme
+
+---@diagnostic disable: undefined-global
+local theme = Colorscheme.define('your_theme', function()
+    ---- De Facto groups ------------------------ {{{
+    -- These groups are not listed as default vim groups
+    -- but they are defacto standard group names for syntax highlighting.
+
+    -- Uncomment and edit if you want more specific syntax highlighting.
+
+    -- Normal {}
+    -- Comment {}
+    -- NormalFloat {}             -- Normal text in floating windows.
+    -- FloatBorder {}             -- Border of floating windows
+    -- Conceal {}                 -- placeholder characters substituted for concealed text (see 'conceallevel')
+    -- Cursor { Reverse }         -- character under the cursor
+    -- lCursor {}                 -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+    -- CursorIM {}                -- like Cursor, but used when in IME mode |CursorIM|
+    -- Directory {}               -- directory names (and other special names in listings)
+    -- netrwClassify {}           -- trailing slash on directory names in netrw
+
+    -- Constant {}                -- (preferred) any constant
+    -- String {}                  -- a string constant: "this is a string"
+    -- Character {}               -- a character constant: 'c', '\n'
+    -- Number { Constant }        -- a number constant: 234, 0xff
+    -- Boolean { Constant }       -- a boolean constant: TRUE, false
+    -- Float { Constant }         -- a floating point constant: 2.3e10
+
+    -- Identifier {}              -- (preferred) any variable name
+    -- Function { Identifier }    -- function name (also: methods for classes)
+
+    -- Statement {}               -- (preferred) any statement
+    -- Conditional { Statement }  -- if, then, else, endif, switch, etc.
+    -- Repeat { Statement }       -- for, do, while, etc.
+    -- Label { Statement }        -- case, default, etc.
+    -- Operator { Statement }     -- "sizeof", "+", "*", etc.
+    -- Keyword { Statement }      -- any other keyword
+    -- Exception { Statement }    -- try, catch, throw
+
+    -- PreProc {}                 -- (preferred) generic Preprocessor
+    -- Include { PreProc }        -- preprocessor #include
+    -- Define { PreProc }         -- preprocessor #define
+    -- Macro { PreProc }          -- same as Define
+    -- PreCondit { PreProc }      -- preprocessor #if, #else, #endif, etc.
+
+    -- Type {}                    -- (preferred) int, long, char, etc.
+    -- StorageClass { Type }      -- static, register, volatile, etc.
+    -- Structure { Type }         -- struct, union, enum, etc.
+    -- Typedef { Type }           -- A typedef
+
+    -- Special {}                 -- (preferred) any special symbol
+    -- SpecialChar { Special }    -- special character in a constant
+    -- Tag { Special }            -- you can use CTRL-] on this
+    -- Delimiter { Special }      -- character that needs attention
+    -- SpecialComment { Special } -- special things inside a comment
+    -- Debug { Special }          -- debugging statements
+
+    -- ("Ignore", below, may be invisible...)
+    -- Ignore {}              -- (preferred) left blank, hidden  |hl-Ignore|
+
+    -- Todo {}                -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+    -- Error {}               -- (preferred) any erroneous construct
+
+    -- Git
+    -- diffFile {}
+    -- diffIndexLine { Identifier, Italic }
+    -- diffAdded {}     -- diff mode: Added line |diff.txt|
+    -- DiffAdd { diffAdded }
+    -- diffChanged {}   -- diff mode: Changed line |diff.txt|
+    -- DiffChange { diffChanged }
+    -- diffRemoved {}   -- diff mode: Deleted line |diff.txt|
+    -- DiffDelete { diffRemoved }
+    -- DiffText {}      -- diff mode: Changed text within a changed line |diff.txt|
+    -- diffLine { Constant }
+    -- diffSubname {}
+    -- diffOldFile {}
+    -- diffNewFile {}
+
+    -- TermCursor {}               -- cursor in a focused terminal
+    -- TermCursorNC {}             -- cursor in an unfocused terminal
+    -- ErrorMsg { Error }          -- error messages on the command line
+    -- VertSplit {}                -- the column separating vertically split windows
+
+    -- Folded {}                   -- line used for closed folds
+    -- ColorColumn { NormalFloat } -- used for the columns set with 'colorcolumn'
+    -- FoldColumn {}               -- 'foldcolumn'
+    -- SignColumn {}               -- column where |signs| are displayed
+    -- CursorColumn {}             -- used for the columns set with 'cursorcolumn'
+    -- CursorLine {}               -- used for the row set with 'cursorline'
+    -- CursorLineNr {}             -- used for the row set with 'cursorline'
+    -- LineNr { Comment }
+
+    -- MatchParen {}           -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
+    -- ModeMsg {}              -- 'showmode' message (e.g., "-- INSERT -- "
+    -- MsgArea {}              -- Area for messages and cmdline
+    -- MsgSeparator {}         -- Separator for scrolled messages, `msgsep` flag of 'display'
+    -- MoreMsg {}              -- |more-prompt|
+    -- NonText { Comment }     -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+    -- EndOfBuffer {}          -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+    -- NormalNC {}             -- normal text in non-current windows
+    -- Pmenu {}                -- Popup menu: normal item.
+    -- PmenuSel {}             -- Popup menu: selected item.
+    -- PmenuSbar {}            -- Popup menu: scrollbar.
+    -- PmenuThumb {}           -- Popup menu: Thumb of the scrollbar.
+    -- Question {}             -- |hit-enter| prompt and yes/no questions
+    -- SpecialKey {}           -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
+    -- SpellBad {}             -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
+    -- SpellCap {}             -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
+    -- SpellLocal {}           -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
+    -- SpellRare {}            -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
+    -- StatusLine {}           -- status line of current window
+    -- StatusLineNC {}         -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+    -- TabLine {}              -- tab pages line, not active tab page label
+    -- TabLineFill {}          -- tab pages line, where there are no labels
+    -- TabLineSel {}           -- tab pages line, active tab page label
+    -- WinBar {}               -- window bar of the current window
+    -- WinBarNC {}             -- window bars of not-current windows
+    -- Title {}                -- titles for output from ":set all", ":autocmd" etc.
+    -- Visual {}               -- Visual mode selection
+    -- VisualNOS {}            -- Visual mode selection when vim is "Not Owning the Selection".
+    -- WarningMsg {}           -- warning messages
+    -- Whitespace { Comment }  -- "nbsp", "space", "tab" and "trail" in 'listchars'
+    -- WildMenu { Visual }     -- current match in 'wildmenu' completion
+    -- Search {}
+    -- QuickFixLine {}         -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
+    -- Substitute {}           -- |:substitute| replacement text highlighting
+
+    -- }}}
+    ---- LSP groups ----------------------------- {{{
+    -- These groups are for the native LSP client. Some other LSP clients may use
+    -- these groups, or use their own. Consult your LSP client's documentation.
+
+    -- DiagnosticError { Error }                                       -- used for "Error" diagnostic virtual text
+    -- LspDiagnosticsDefaultError { DiagnosticError }                  -- used for "Error" diagnostic virtual text
+    -- LspDiagnosticsError { LspDiagnosticsDefaultError }              -- used for "Error" diagnostic virtual text
+    -- LspDiagnosticsErrorSign { LspDiagnosticsError }                 -- used for "Error" diagnostic signs in sign column
+    -- LspDiagnosticsErrorFloating { LspDiagnosticsError }             -- used for "Error" diagnostic messages in the diagnostics float
+    -- DiagnosticWarn {}                                               -- used for "Warning" diagnostic virtual text
+    -- LspDiagnosticsDefaultWarning { DiagnosticWarn }
+    -- LspDiagnosticsWarning { LspDiagnosticsDefaultWarning }          -- used for "Warning" diagnostic virtual text
+    -- LspDiagnosticsWarningSign { LspDiagnosticsWarning }             -- used for "Warning" diagnostic signs in sign column
+    -- LspDiagnosticsWarningFloating { LspDiagnosticsWarning }         -- used for "Warning" diagnostic messages in the diagnostics float
+    -- DiagnosticInfo {}                                               -- used for "Information" diagnostic virtual text
+    -- LspDiagnosticsDefaultInformation { DiagnosticInfo }
+    -- LspDiagnosticsInformation { LspDiagnosticsDefaultInformation }  -- used for "Information" diagnostic virtual text
+    -- LspDiagnosticsInformationSign { LspDiagnosticsInformation }     -- used for "Information" signs in sign column
+    -- LspDiagnosticsInformationFloating { LspDiagnosticsInformation } -- used for "Information" diagnostic messages in the diagnostics float
+    -- DiagnosticHint {}                                               -- used for "Hint" diagnostic virtual text
+    -- LspDiagnosticsDefaultHint { DiagnosticHint }
+    -- LspDiagnosticsHint { LspDiagnosticsDefaultHint }                -- used for "Hint" diagnostic virtual text
+    -- LspDiagnosticsHintSign { LspDiagnosticsHint }                   -- used for "Hint" diagnostic signs in sign column
+    -- LspDiagnosticsHintFloating { LspDiagnosticsHint }               -- used for "Hint" diagnostic messages in the diagnostics float
+    -- LspReferenceText {}                                             -- used for highlighting "text" references
+    -- LspReferenceRead {}                                             -- used for highlighting "read" references
+    -- LspReferenceWrite {}                                            -- used for highlighting "write" references
+    -- DiagnosticUnderlineError { DiagnosticError, Underline }
+    -- DiagnosticUnderlineWarn { DiagnosticWarn, Underline }
+    -- DiagnosticUnderlineInfo { DiagnosticInfo, Underline }
+    -- DiagnosticUnderlineHint { DiagnosticHint, Underline }
+    -- LspDiagnosticsVirtualTextError { LspDiagnosticsError }
+    -- LspDiagnosticsVirtualTextWarning { LspDiagnosticsWarning }
+    -- LspDiagnosticsVirtualTextInformation { LspDiagnosticsInformation }
+    -- LspDiagnosticsVirtualTextHint { LspDiagnosticsHint }
+
+    -- LspSignatureActiveParameter { WildMenu }
+    -- }}}
+    ---- Treesitter groups ---------------------- {{{
+    -- These groups are for the neovim tree-sitter highlights.
+    -- As of writing, tree-sitter support is a WIP, group names may change.
+    -- By default, most of these groups link to an appropriate Vim group.
+    --
+    -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights
+
+    --- Misc {{{
+    -- _ "@comment" {}                   -- line and block comments
+    -- _ "@error" { Error }              -- syntax/parser errors
+    -- _ "@none" {}                      -- completely disable the highlight
+    -- _ "@keyword.directive" {}         -- various preprocessor directives & shebangs
+    -- _ "@keyword.directive.define" {}  -- preprocessor definition directives
+    -- _ "@operator" {}                  -- symbolic operators (e.g. `+` / `*`)
+
+    -- }}}
+    --- Punctuation {{{
+    -- _ "@punctuation.delimiter" {}  -- For delimiters ie: `.`
+    -- _ "@punctuation.bracket" {}    -- For brackets and parens.
+    -- _ "@punctuation.special" {}    -- For special punctuation that does not fall in the categories before.
+
+    -- }}}
+    --- Literals {{{
+    -- _ "@string" {}                 -- string literals
+    -- _ "@string.regexp" {}          -- regular expressions
+    -- _ "@string.escape" {}          -- escape sequences
+    -- _ "@string.special" {}         -- other special strings (e.g. dates)
+
+    -- _ "@character" {}              -- character literals
+    -- _ "@character.special" {}      -- special characters (e.g. wildcards)
+
+    -- _ "@boolean" {}                -- boolean literals
+    -- _ "@number" {}                 -- numeric literals
+    -- _ "@number.float" {}           -- floating-point number literals
+
+    -- }}}
+    --- Functions {{{
+    -- _ "@function" {}               -- function definitions
+    -- _ "@function.builtin" {}       -- built-in functions
+    -- _ "@function.call" {}          -- function calls
+    -- _ "@function.macro" {}         -- preprocessor macros
+
+    -- _ "@function.method" {}        -- method definitions
+    -- _ "@function.method.call" {}   -- method calls
+
+    -- _ "@constructor" { Type }      -- constructor calls and definitions
+    -- _ "@variable.parameter" {}     -- parameters of a function
+
+    -- }}}
+    --- Keywords {{{
+    -- _ "@keyword" {}                -- various keywords
+    -- _ "@keyword.function" {}       -- keywords that define a function (e.g. `func` in Go, `def` in Python)
+    -- _ "@keyword.operator" {}       -- operators that are English words (e.g. `and` / `or`)
+    -- _ "@keyword.return" {}         -- keywords like `return` and `yield`
+
+    -- _ "@keyword.conditional" {}    -- keywords related to conditionals (e.g. `if` / `else`)
+    -- _ "@keyword.repeat" {}         -- keywords related to loops (e.g. `for` / `while`)
+    -- _ "@keyword.debug" {}          -- keywords related to debugging
+    -- _ "@label" {}                  -- GOTO and other labels (e.g. `label:` in C)
+    -- _ "@keyword.include" {}        -- keywords for including modules (e.g. `import` / `from` in Python)
+    -- _ "@keyword.exception" {}      -- keywords related to exceptions (e.g. `throw` / `catch`)
+
+    -- }}}
+    --- Types {{{
+    -- _ "@type" {}                           -- type or class definitions and annotations
+    -- _ "@type.builtin" {}                   -- built-in types
+    -- _ "@type.definition" {}                -- type definitions (e.g. `typedef` in C)
+    -- _ "@type.qualifier" {}                 -- type qualifiers (e.g. `const`)
+
+    -- _ "@keyword.storage" {}                -- visibility/life-time/etc. modifiers (e.g. `static`)
+    -- _ "@attribute" {}                      -- attribute annotations (e.g. Python decorators)
+    -- _ "@variable.member" {}                -- object and struct fields
+    -- _ "@property" { _ "@variable.member" } -- similar to `@field`
+
+    -- }}}
+    --- Identifiers {{{
+    -- _ "@variable" {}               -- various variable names
+    -- _ "@variable.builtin" {}       -- built-in variable names (e.g. `this`)
+
+    -- _ "@constant" {}               -- constant identifiers
+    -- _ "@constant.builtin" {}       -- built-in constant values
+    -- _ "@constant.macro" {}         -- constants defined by the preprocessor")
+
+    -- _ "@module" {}                 -- modules or namespaces
+
+    -- }}}
+    --- Text {{{
+    -- _ "@markup" {}                                        -- non-structured text
+    -- _ "@markup.strong" { Bold }                           -- bold text
+    -- _ "@markup.italic" { Italic }                         -- text with emphasis
+    -- _ "@markup.underline" { Underline }                   -- underlined text
+    -- _ "@markup.strikethrough" { Strikethrough }           -- strikethrough text
+    -- _ "@markup.heading" { Title }                         -- text that is part of a title
+    -- _ "@markup.raw" {}                                    -- literal or verbatim text
+    -- _ "@markup.quote" {}                                  -- block quotes
+    -- _ "@markup.math" {}                                   -- math environments (e.g. `$ ... $` in LaTeX)
+    -- _ "@markup.environment" {}                            -- text environments of markup languages
+    -- _ "@markup.environment.name" {}                       -- text indicating the type of an environment
+    -- _ "@markup.link" {}                                   -- text references, footnotes, citations, etc.
+    -- _ "@markup.link.label" { Bold }                       -- link, reference descriptions
+    -- _ "@markup.link.url" { Underline }                    -- URL-style links
+    -- _ "@markup.list" { Statement }                        -- list markers
+    -- _ "@markup.list.unnumbered" {}                        -- unnumbered lists
+    -- _ "@markup.list.numbered" {}                          -- numbered lists
+    -- _ "@markup.list.checked" {}                           -- checked todo-style list markers
+    -- _ "@markup.list.unchecked" {}                         -- unchecked todo-style list markers
+
+    -- _ "@string.special.symbol" {}                         -- symbols or atoms
+    -- _ "@string.special.url" {}                            -- URIs (e.g. hyperlinks)
+    -- _ "@string.documentation" { Comment }                 -- documentation strings
+
+    -- _ "@comment.todo" { Todo, fg = DiagnosticHint.fg }    -- todo notes
+    -- _ "@comment.note" { Todo, fg = DiagnosticInfo.fg }    -- info notes
+    -- _ "@comment.warning" { Todo, fg = DiagnosticWarn.fg } -- warning notes
+    -- _ "@comment.error" { Todo, fg = DiagnosticError.fg }  -- danger/error notes
+
+    -- _ "@diff.plus" { DiffAdd }                            -- Added line
+    -- _ "@diff.plus.gutter" { _ "@diff.plus" }              -- Added gutter indicator
+    -- _ "@diff.minus" { DiffDelete }                        -- Deleted line
+    -- _ "@diff.minus.gutter" { _ "@diff.minus" }            -- Deleted gutter indicator
+    -- _ "@diff.delta" { DiffChange }                        -- Changed line
+    -- _ "@diff.delta.moved" {}                              -- Moved line
+    -- _ "@diff.delta.conflict" {}                           -- line with conflicts
+    -- _ "@diff.delta.gutter" { _ "@diff.delta" }            -- Changed gutter indicator
+
+    -- }}}
+    --- Tags {{{
+    -- _ "@tag" {}                       -- XML tag names
+    -- _ "@tag.attribute" { Identifier } -- XML tag attributes
+    -- _ "@tag.delimiter" {}             -- XML tag delimiters
+
+    -- }}}
+    -- }}}
+end)
+
+return theme

--- a/lua/polychrome/utils.lua
+++ b/lua/polychrome/utils.lua
@@ -81,7 +81,7 @@ function M.escape(s, prefix)
 
     -- generate a table like { char = prefix .. char }
     local mapped = vim.tbl_map(function(c) return { [c] = prefix .. c } end, special)
-    local flattened = vim.tbl_flatten(mapped)
+    local flattened = vim.iter(mapped):flatten():totable()
 
     return s:gsub(".", flattened)
 end
@@ -154,6 +154,11 @@ function M.sign(x)
     else
         return 0
     end
+end
+
+function M.get_plugin_root()
+    local root = debug.getinfo(2, "S").source:sub(2)
+    return root:match("(.*/)")
 end
 
 return M


### PR DESCRIPTION
Modifies the existing user commands:

* `:StartPreview` => `:Polychrome preview start`
* `:StopPreview` => `:Polychrome preview stop`

Also adds a new `template` subcommand for loading templates:

* `:Polychrome template theme` - loads a template with all the common highlight groups
